### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/src/SimpleHome/SimpleHome.php
+++ b/src/SimpleHome/SimpleHome.php
@@ -20,6 +20,7 @@ class SimpleHome extends PluginBase{
             $this->database = new \SQLite3($this->getDataFolder() . "homes.db", SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE);
             $resource = $this->getResource("sqlite3.sql");
             $this->database->exec(stream_get_contents($resource));
+            @fclose($resource);
         }else{
             $this->database = new \SQLite3($this->getDataFolder() . "homes.db", SQLITE3_OPEN_READWRITE);
         }


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:

* `Plugin->getResource()` without `fclose()` calls later
* Not needed `Plugin->getResource()` calls
* `fopen()` calls without `fclose()`
* `popen()` calls without `pclose()`